### PR TITLE
Remove notification shown when using environment variable setup

### DIFF
--- a/lua/kotlin.lua
+++ b/lua/kotlin.lua
@@ -146,8 +146,6 @@ function M.setup_kotlin_lsp(opts)
       vim.notify("The 'lib' directory does not exist at: " .. lib_dir, vim.log.levels.ERROR)
       return
     end
-
-    vim.notify("Using Kotlin LSP from environment variable: " .. lib_dir, vim.log.levels.INFO)
   end
 
   local default_jvm_args = {


### PR DESCRIPTION
Hi!

Previously, a notification was displayed when the Kotlin language server was configured via environment variables.
This was inconsistent with the Mason setup method, which doesn't show notifications. 

This PR removes the notification to provide a consistent setup experience across both installation methods.

Thank you for providing such a wonderful plugin!
