### PR TITLE
configure kotlin_lsp correctly

### DIFF
--- a/lua/kotlin.lua
+++ b/lua/kotlin.lua
@@ -56,7 +56,7 @@ function M.clean_workspace()
   vim.notify("Cleaning workspace for " .. project_name, vim.log.levels.INFO)
 
   -- Stop existing Kotlin LSP clients
-  for _, client in ipairs(vim.lsp.get_clients({ name = "kotlin_ls" })) do
+  for _, client in ipairs(vim.lsp.get_clients({ name = "kotlin_lsp" })) do
     vim.notify("Stopping Kotlin LSP...", vim.log.levels.INFO)
     vim.lsp.stop_client(client.id)
     vim.cmd("sleep 500m")
@@ -255,6 +255,9 @@ function M.setup_kotlin_lsp(opts)
     }
   end
 
+  -- All launcher paths resolve to the single registered config.
+  vim.lsp.enable("kotlin_lsp")
+
   -- Pass additional JVM args via IJ_JAVA_OPTIONS environment variable
   if opts.jvm_args and type(opts.jvm_args) == "table" and #opts.jvm_args > 0 then
     cmd_env = { IJ_JAVA_OPTIONS = table.concat(opts.jvm_args, " ") }
@@ -316,7 +319,7 @@ function M.setup_kotlin_lsp(opts)
     init_options.buildTools = { [workspace_uri] = opts.build_tool }
   end
 
-  vim.lsp.config.kotlin_ls = {
+  vim.lsp.config.kotlin_lsp = {
     cmd = cmd,
     cmd_env = cmd_env,
     filetypes = { "kotlin" },
@@ -399,8 +402,6 @@ function M.setup_kotlin_lsp(opts)
       end,
     },
   }
-
-  vim.lsp.enable("kotlin_ls")
 end
 
 M.settings = { uri_timeout_ms = 5000 }

--- a/lua/kotlin/autocommands.lua
+++ b/lua/kotlin/autocommands.lua
@@ -37,7 +37,7 @@ function M.setup_inlay_hints(opts)
     group = augroup,
     callback = function(args)
       local client = vim.lsp.get_client_by_id(args.data.client_id)
-      if client and client.name == "kotlin_ls" then
+      if client and client.name == "kotlin_lsp" then
         local bufnr = args.buf
 
         -- Check if the client supports inlay hints
@@ -74,7 +74,7 @@ function M.setup_folding(opts)
     group = augroup,
     callback = function(args)
       local client = vim.lsp.get_client_by_id(args.data.client_id)
-      if not (client and client.name == "kotlin_ls") then
+      if not (client and client.name == "kotlin_lsp") then
         return
       end
       if not client.server_capabilities.foldingRangeProvider then

--- a/lua/kotlin/commands.lua
+++ b/lua/kotlin/commands.lua
@@ -27,7 +27,7 @@ end
 -- Organize imports in the current buffer
 function M.organize_imports()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -72,7 +72,7 @@ end
 -- Enhanced code actions for Kotlin - shows only Kotlin-specific actions
 function M.code_actions()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -80,10 +80,10 @@ function M.code_actions()
   end
 
   -- Use the standard code action but it will only show kotlin-lsp actions
-  -- since we filtered to kotlin_ls client
+  -- since we filtered to kotlin_lsp client
   vim.lsp.buf.code_action({
     filter = function(_)
-      -- Only show actions from kotlin_ls
+      -- Only show actions from kotlin_lsp
       return true
     end,
   })
@@ -92,7 +92,7 @@ end
 -- Quick fix for the diagnostic under cursor (if any)
 function M.quick_fix()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -122,7 +122,7 @@ end
 -- Format the current buffer using kotlin-lsp
 function M.format_buffer()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -131,7 +131,7 @@ function M.format_buffer()
 
   vim.lsp.buf.format({
     async = false,
-    name = "kotlin_ls",
+    name = "kotlin_lsp",
   })
 
   vim.notify("Buffer formatted", vim.log.levels.INFO)
@@ -140,7 +140,7 @@ end
 -- Show document symbols (outline)
 function M.document_symbols()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -201,7 +201,7 @@ end
 
 -- Search workspace symbols
 function M.workspace_symbols()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls" })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp" })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not running", vim.log.levels.ERROR)
@@ -214,7 +214,7 @@ end
 -- Find all references to symbol under cursor
 function M.find_references()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -227,7 +227,7 @@ end
 -- Go to type definition of symbol under cursor
 function M.type_definition()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -240,7 +240,7 @@ end
 -- Go to implementation of symbol under cursor
 function M.implementation()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -254,7 +254,7 @@ end
 -- Requires kotlin-lsp v262.4739.0+.
 function M.incoming_calls()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -268,7 +268,7 @@ end
 -- Requires kotlin-lsp v262.4739.0+.
 function M.outgoing_calls()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)
@@ -281,7 +281,7 @@ end
 -- Rename symbol under cursor
 function M.rename_symbol()
   local bufnr = vim.api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls", bufnr = bufnr })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp", bufnr = bufnr })
 
   if #clients == 0 then
     vim.notify("Kotlin LSP not attached to buffer", vim.log.levels.ERROR)

--- a/lua/kotlin/dap.lua
+++ b/lua/kotlin/dap.lua
@@ -63,7 +63,7 @@ local function ensure_adapter()
   -- Only set if not already configured by the user.
   if not dap.adapters.kotlin then
     dap.adapters.kotlin = function(cb)
-      local clients = vim.lsp.get_clients({ name = "kotlin_ls" })
+      local clients = vim.lsp.get_clients({ name = "kotlin_lsp" })
       if #clients == 0 then
         vim.notify("kotlin.nvim: Kotlin LSP not running. Open a Kotlin file first.", vim.log.levels.ERROR)
         return

--- a/lua/kotlin/decompiler.lua
+++ b/lua/kotlin/decompiler.lua
@@ -22,7 +22,7 @@ function M.open_classfile(fname)
     end
   end
 
-  local clients = lsp.get_clients({ name = "kotlin_ls" })
+  local clients = lsp.get_clients({ name = "kotlin_lsp" })
   local client = clients[1]
 
   assert(client, "Must have a `kotlin-ls` client to load class file or jdt uri")

--- a/lua/kotlin/file_templates.lua
+++ b/lua/kotlin/file_templates.lua
@@ -139,7 +139,7 @@ function M.setup(opts)
 
   local augroup = vim.api.nvim_create_augroup("KotlinFileTemplates", { clear = true })
 
-  -- Try to prompt now if the buffer is empty and kotlin_ls is attached.
+  -- Try to prompt now if the buffer is empty and kotlin_lsp is attached.
   -- Otherwise mark it pending so LspAttach can pick it up later.
   -- The `kotlin_template_prompted` flag prevents re-prompting on every
   -- BufEnter (tab switches, window cycling, etc.).
@@ -156,7 +156,7 @@ function M.setup(opts)
       return
     end
 
-    local clients = vim.lsp.get_clients({ bufnr = bufnr, name = "kotlin_ls" })
+    local clients = vim.lsp.get_clients({ bufnr = bufnr, name = "kotlin_lsp" })
     if #clients == 0 then
       vim.b[bufnr].kotlin_pending_template = true
       return
@@ -181,12 +181,12 @@ function M.setup(opts)
   })
 
   -- Backstop: if the LSP attaches *after* we marked the buffer pending
-  -- (BufEnter fired before kotlin_ls came up), prompt as soon as it's ready.
+  -- (BufEnter fired before kotlin_lsp came up), prompt as soon as it's ready.
   vim.api.nvim_create_autocmd("LspAttach", {
     group = augroup,
     callback = function(args)
       local client = vim.lsp.get_client_by_id(args.data.client_id)
-      if not (client and client.name == "kotlin_ls") then
+      if not (client and client.name == "kotlin_lsp") then
         return
       end
       if not vim.b[args.buf].kotlin_pending_template then

--- a/lua/kotlin/health.lua
+++ b/lua/kotlin/health.lua
@@ -147,15 +147,15 @@ end
 
 local function check_clients()
   start("Active LSP clients")
-  local clients = vim.lsp.get_clients({ name = "kotlin_ls" })
+  local clients = vim.lsp.get_clients({ name = "kotlin_lsp" })
 
   if #clients == 0 then
-    info("No kotlin_ls client attached. Open a .kt file in a Kotlin project to start the server.")
+    info("No kotlin_lsp client attached. Open a .kt file in a Kotlin project to start the server.")
     return
   end
 
   for _, c in ipairs(clients) do
-    ok(("kotlin_ls (id=%d) attached to %d buffer(s)"):format(c.id, vim.tbl_count(c.attached_buffers or {})))
+    ok(("kotlin_lsp (id=%d) attached to %d buffer(s)"):format(c.id, vim.tbl_count(c.attached_buffers or {})))
     info("  cmd: " .. vim.inspect(c.config.cmd))
 
     local caps = c.server_capabilities or {}

--- a/lua/kotlin/lsp.lua
+++ b/lua/kotlin/lsp.lua
@@ -13,7 +13,7 @@ end
 
 function M.execute_command(command, callback, bufnr)
   local clients = {}
-  local candidates = M.get_clients({ name = "kotlin_ls" })
+  local candidates = M.get_clients({ name = "kotlin_lsp" })
 
   for _, c in pairs(candidates) do
     local command_provider = c.server_capabilities.executeCommandProvider


### PR DESCRIPTION
Hi! :wave: 

I'm quite new to kotlin and have therefore a "modern" setup(kotlin_lsp, jdk 25 and newest kotlin sdk). This does not work nicely with legacy kotlin_ls. When I used your plugin, both language server started, but kotlin_ls never finished starting, because I didn't install it via mason. Then I found out, that kotlin.nvim enables kotlin_ls but never kotlin_lsp.
This PR now changes this behaviour: the new kotlin_lsp gets enabled if the language server is started and the other way around, if the legacy language server is started. health.lua and commands.lua are changed accordingly for taking both language server into account.