### PR TITLE
fix: send inlay hint options under the server's actual optionIds

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 > - The plugin launches kotlin-lsp via its `bin/intellij-server` native launcher, which requires kotlin-lsp **v262.4739.0+**. Older builds that only ship the `kotlin-lsp.sh` / `kotlin-lsp.cmd` shim are no longer supported — update your install.
 > - Workspace isolation with the `--system-path` parameter requires kotlin-lsp **v0.253.10629** or later.
 > - Zero-dependencies platform-specific builds are supported -- no JDK required by default as the language server bundles its own (kotlin-lsp **v261+** or later).
-> - Inlay hints require kotlin-lsp **v261+** and are configured using the exact format from the VSCode extension.
+> - Inlay hints require kotlin-lsp **v261+**. The server requests the `jetbrains.kotlin` configuration section dynamically and only renders hints whose option is answered with `true` — kotlin.nvim implements this handler, so the kotlin_lsp client must be started by kotlin.nvim (see the mason-lspconfig note below).
 > - Code formatting and organize imports require kotlin-lsp **v0.253+** with IntelliJ IDEA-based formatting support.
 > - "Go to Type Definition" and "Go to Implementation" require kotlin-lsp **v262+**.
 > - Maven project import is supported starting from kotlin-lsp **v262+**.
@@ -102,6 +102,16 @@ Install the plugin with your package manager:
 
 **Optional (install and configure separately):**
 - Debug Adapter Protocol client ([nvim-dap](https://github.com/mfussenegger/nvim-dap)). Required for `:KotlinDebug`. kotlin.nvim does not install or configure nvim-dap for you — set it up once globally (signs, keymaps, optional UI) and kotlin.nvim will register a `kotlin` adapter on top.
+
+> [!important]
+> **Using mason-lspconfig?** Do not let it auto-enable `kotlin_lsp`. mason-lspconfig's `automatic_enable` starts
+> kotlin_lsp from nvim-lspconfig's default config *before* kotlin.nvim configures it. That client lacks the `workspace/configuration` handler kotlin-lsp needs, so **all inlay hints disappear** and kotlin.nvim settings are ignored. Exclude kotlin_lsp and let kotlin.nvim start it:
+>
+> ```lua
+> require("mason-lspconfig").setup {
+>     automatic_enable = { exclude = { "kotlin_lsp" } },
+> }
+> ```
 
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
@@ -154,6 +164,7 @@ Install the plugin with your package manager:
                 parameters = true,  -- Show parameter names
                 parameters_compiled = true,  -- Show compiled parameter names
                 parameters_excluded = false,  -- Show excluded parameter names
+                parameters_context = false,  -- Show context parameter hints
                 types_property = true,  -- Show property types
                 types_variable = true,  -- Show local variable types
                 function_return = true,  -- Show function return types
@@ -359,7 +370,7 @@ require("kotlin").setup {
 
 #### All Available Settings
 
-All settings default to `true` except `parameters_excluded` and `call_chains`. Only specify settings you want to change:
+All settings default to `true` except `parameters_excluded`, `parameters_context` and `call_chains`. Only specify settings you want to change:
 
 ```lua
 require("kotlin").setup {
@@ -370,6 +381,7 @@ require("kotlin").setup {
         parameters = true,  -- foo(name: "value", age: 42)
         parameters_compiled = true,  -- Show parameter names for compiled code
         parameters_excluded = false,  -- Show hints for excluded parameters (usually false)
+        parameters_context = false,  -- Show context parameter hints (usually false)
 
         -- Type hints (show inferred types)
         types_property = true,  -- val name: String = "foo"
@@ -397,6 +409,7 @@ require("kotlin").setup {
 | `parameters` | `true` | Show parameter names in function calls |
 | `parameters_compiled` | `true` | Show parameter names for compiled/external functions |
 | `parameters_excluded` | `false` | Show parameter names for excluded parameters |
+| `parameters_context` | `false` | Show context parameter hints |
 | `types_property` | `true` | Show type hints for properties |
 | `types_variable` | `true` | Show type hints for local variables |
 | `function_return` | `true` | Show return type hints for functions |
@@ -425,7 +438,7 @@ end, { desc = 'Toggle inlay hints' })
 
 #### Implementation Note
 
-Inlay hints work by implementing a `workspace/configuration` handler that responds to server requests for the `jetbrains.kotlin` configuration section. The handler builds a properly nested configuration object matching the VSCode extension format. This is crucial because kotlin-lsp requests configuration dynamically rather than using only the initial settings.
+Inlay hints work by implementing a `workspace/configuration` handler that responds to server requests for the `jetbrains.kotlin` configuration section — kotlin-lsp requests configuration dynamically on every inlay hint request rather than using only the initial settings. The server flattens the response into dot-paths and string-matches them against IntelliJ's declarative inlay hint optionIds (`hints.parameters`, `hints.type.property`, `hints.lambda.return`, `hints.value.ranges`, ...), and only renders hints whose optionId is answered with `true`. Note that the key names deliberately differ from the JetBrains VS Code extension's `package.json` for four options — the extension contributes bundle name keys (`hints.settings.types.property`, ...) that the server never matches.
 
 ### Code Folding
 

--- a/doc/kotlin.nvim.txt
+++ b/doc/kotlin.nvim.txt
@@ -48,7 +48,8 @@ setup({opts})                                                          *kotlin.s
                 Requires kotlin-lsp v262.4739.0+. Mirrors VSCode's
                 `intellij.buildTool` setting (LSP-807).
             • inlay_hints: Configuration for inlay hints (see |kotlin.nvim.inlayhints|)
-                All settings default to true (except parameters_excluded)
+                All settings default to true (except parameters_excluded,
+                parameters_context and call_chains)
             • folding: { enabled = boolean } — enable LSP-driven folding
                 for Kotlin buffers. Default true. Requires kotlin-lsp
                 v262.4739.0+ and Neovim 0.11+.
@@ -78,8 +79,8 @@ setup({opts})                                                          *kotlin.s
 
 Inlay Hints                                                      *kotlin.nvim.inlayhints*
 
-kotlin.nvim provides full LSP inlay hints support matching the VSCode extension
-configuration format. All hint types can be individually enabled or disabled.
+kotlin.nvim provides full LSP inlay hints support. All hint types can be
+individually enabled or disabled.
 
 Requirements: ~
 - kotlin-lsp version 0.254 or later
@@ -98,14 +99,17 @@ Minimal configuration enables all hints with defaults:
 
 Configuration Options: ~
 
-All settings are optional and default to `true` (except `parameters_excluded`
-which defaults to `false`). Only specify settings you want to change.
+All settings are optional and default to `true` (except `parameters_excluded`,
+`parameters_context` and `call_chains` which default to `false`). Only specify
+settings you want to change.
 
 enabled                     Master switch to enable/disable all inlay hints
 parameters                  Show parameter names in function calls
                             Example: foo(name: "value", age: 42)
 parameters_compiled         Show parameter names for compiled/external functions
 parameters_excluded         Show parameter names for excluded parameters
+                            Usually kept false
+parameters_context          Show context parameter hints
                             Usually kept false
 types_property              Show type hints for properties
                             Example: val name: String = "foo"
@@ -120,6 +124,8 @@ lambda_return               Show return type hints for lambdas
 lambda_receivers_parameters Show receiver and parameter hints for lambdas
 value_ranges                Show hints for value ranges
 kotlin_time                 Show kotlin.time package warnings
+call_chains                 Show intermediate result types in method-call
+                            chains. Usually kept false
 
 Complete Example: ~
 >lua
@@ -129,6 +135,7 @@ Complete Example: ~
             parameters = true,
             parameters_compiled = true,
             parameters_excluded = false,
+            parameters_context = false,
             types_property = true,
             types_variable = true,
             function_return = true,
@@ -137,6 +144,7 @@ Complete Example: ~
             lambda_receivers_parameters = true,
             value_ranges = true,
             kotlin_time = true,
+            call_chains = false,
         },
     }
 <
@@ -235,10 +243,12 @@ inlay hints. Use `KotlinInlayHintsToggle` for LSP inlay hints.
 Implementation: ~
 
 Inlay hints work by implementing a workspace/configuration handler that
-responds to server requests. When kotlin-lsp requests the "jetbrains.kotlin"
-configuration section, the plugin builds a properly nested object structure
-matching the VSCode extension format. This dynamic configuration request
-handling is crucial for inlay hints to work.
+responds to server requests. kotlin-lsp requests the "jetbrains.kotlin"
+configuration section on every inlay hint request, flattens the response into
+dot-paths and matches them against IntelliJ's declarative inlay hint
+optionIds (hints.parameters, hints.type.property, hints.lambda.return, ...).
+Only hints whose optionId is answered with true are rendered, so the client
+that handles this request must be the one started by kotlin.nvim.
 
 ==========================================================================================
 

--- a/lua/kotlin.lua
+++ b/lua/kotlin.lua
@@ -152,6 +152,34 @@ local function resolve_root(bufnr, root_markers, fallback)
   return fallback
 end
 
+-- Map plugin options to kotlin-lsp inlay hint optionIds, keyed by their path
+-- under the `jetbrains.kotlin.hints` section. The server flattens the
+-- workspace/configuration response for `jetbrains.kotlin` into dot-paths and
+-- string-matches them against IntelliJ's declarative inlay hint optionIds
+-- (InlayInfoOption.kt), so these keys must spell the optionIds exactly.
+-- Note: JetBrains' own VS Code package.json uses the bundle nameKeys
+-- (`hints.settings.types.property`, ...) for four of these — those never
+-- matched and must not be copied here.
+local function inlay_hint_options(inlay)
+  -- stylua: ignore start
+  return {
+    ["parameters"] = inlay.parameters ~= false,
+    ["parameters.compiled"] = inlay.parameters_compiled ~= false,
+    ["parameters.excluded"] = inlay.parameters_excluded == true,
+    ["parameters.context"] = inlay.parameters_context == true,
+    ["type.property"] = inlay.types_property ~= false,
+    ["type.variable"] = inlay.types_variable ~= false,
+    ["type.function.return"] = inlay.function_return ~= false,
+    ["type.function.parameter"] = inlay.function_parameter ~= false,
+    ["lambda.return"] = inlay.lambda_return ~= false,
+    ["lambda.receivers.parameters"] = inlay.lambda_receivers_parameters ~= false,
+    ["value.ranges"] = inlay.value_ranges ~= false,
+    ["value.kotlin.time"] = inlay.kotlin_time ~= false,
+    ["call.chains"] = inlay.call_chains == true,
+  }
+  -- stylua: ignore end
+end
+
 function M.setup_kotlin_lsp(opts)
   -- Honor the buffer flag / `.disable-kotlin-lsp` marker. This reactive check
   -- also stops a client already running on this buffer. The config's `root_dir`
@@ -263,27 +291,17 @@ function M.setup_kotlin_lsp(opts)
   local root_markers = opts.root_markers or default_root_markers
 
   -- Build LSP settings with support for new features
+  ---@type table<string, integer|boolean>
   local settings = {
     uri_timeout_ms = 5000,
   }
 
   -- Add inlay hints configuration if specified
-  -- These are flat boolean settings at the top level, matching VSCode extension format
+  -- These are flat boolean settings at the top level, one per optionId
   if opts.inlay_hints then
-    -- stylua: ignore start
-    settings["jetbrains.kotlin.hints.parameters"] = opts.inlay_hints.parameters ~= false
-    settings["jetbrains.kotlin.hints.parameters.compiled"] = opts.inlay_hints.parameters_compiled ~= false
-    settings["jetbrains.kotlin.hints.parameters.excluded"] = opts.inlay_hints.parameters_excluded == true
-    settings["jetbrains.kotlin.hints.settings.types.property"] = opts.inlay_hints.types_property ~= false
-    settings["jetbrains.kotlin.hints.settings.types.variable"] = opts.inlay_hints.types_variable ~= false
-    settings["jetbrains.kotlin.hints.type.function.return"] = opts.inlay_hints.function_return ~= false
-    settings["jetbrains.kotlin.hints.type.function.parameter"] = opts.inlay_hints.function_parameter ~= false
-    settings["jetbrains.kotlin.hints.settings.lambda.return"] = opts.inlay_hints.lambda_return ~= false
-    settings["jetbrains.kotlin.hints.lambda.receivers.parameters"] = opts.inlay_hints.lambda_receivers_parameters ~= false
-    settings["jetbrains.kotlin.hints.settings.value.ranges"] = opts.inlay_hints.value_ranges ~= false
-    settings["jetbrains.kotlin.hints.value.kotlin.time"] = opts.inlay_hints.kotlin_time ~= false
-    settings["jetbrains.kotlin.hints.call.chains"] = opts.inlay_hints.call_chains == true
-    -- stylua: ignore end
+    for option, enabled in pairs(inlay_hint_options(opts.inlay_hints)) do
+      settings["jetbrains.kotlin.hints." .. option] = enabled
+    end
   end
 
   -- Build initialization options (sent during LSP initialization)
@@ -347,47 +365,13 @@ function M.setup_kotlin_lsp(opts)
           local section = item.section
 
           if section == "jetbrains.kotlin" then
-            -- Server requested the jetbrains.kotlin section
-            -- Build a nested object from our flat settings
-            local kotlin_config = { hints = {} }
+            -- The server flattens this response into dot-paths and only
+            -- renders hints whose optionId is present with value true, so
+            -- the keys under `hints` must spell the optionIds exactly.
+            local kotlin_config = vim.empty_dict()
 
             if opts.inlay_hints then
-              kotlin_config.hints = {
-                parameters = opts.inlay_hints.parameters ~= false,
-                ["parameters.compiled"] = opts.inlay_hints.parameters_compiled ~= false,
-                ["parameters.excluded"] = opts.inlay_hints.parameters_excluded == true,
-                settings = {
-                  types = {
-                    property = opts.inlay_hints.types_property ~= false,
-                    variable = opts.inlay_hints.types_variable ~= false,
-                  },
-                  lambda = {
-                    ["return"] = opts.inlay_hints.lambda_return ~= false,
-                  },
-                  value = {
-                    ranges = opts.inlay_hints.value_ranges ~= false,
-                  },
-                },
-                type = {
-                  ["function"] = {
-                    ["return"] = opts.inlay_hints.function_return ~= false,
-                    parameter = opts.inlay_hints.function_parameter ~= false,
-                  },
-                },
-                lambda = {
-                  receivers = {
-                    parameters = opts.inlay_hints.lambda_receivers_parameters ~= false,
-                  },
-                },
-                value = {
-                  kotlin = {
-                    time = opts.inlay_hints.kotlin_time ~= false,
-                  },
-                },
-                call = {
-                  chains = opts.inlay_hints.call_chains == true,
-                },
-              }
+              kotlin_config = { hints = inlay_hint_options(opts.inlay_hints) }
             end
 
             table.insert(result, kotlin_config)


### PR DESCRIPTION
kotlin-lsp flattens the workspace/configuration response for the jetbrains.kotlin section into dot-paths and string-matches them against IntelliJ's declarative inlay hint optionIds. Four options copied the JetBrains VS Code extension's bundle nameKeys (hints.settings.types.property etc) which the server never matches, so property types, variable types, lambda returns and value ranges never rendered.

Fixes #18